### PR TITLE
Error in admin styles "wp_register_style"

### DIFF
--- a/source/php/App.php
+++ b/source/php/App.php
@@ -40,7 +40,7 @@ class App
         wp_register_style(
             'content-scheduler-css',
             CONTENTSCHEDULER_URL . '/dist/' .
-                $this->cacheBust->name('css/content-scheduler.scss')
+                $this->cacheBust->name('css/content-scheduler.css')
         );
 
         wp_enqueue_style('content-scheduler-css');


### PR DESCRIPTION
Everything worked before but didnt look very good. Noticed an error in the wp_register_style
The "dist" is a "css" file, not a "scss". Now everything looks good as well :D
